### PR TITLE
feat: Fetch plant data using trefle

### DIFF
--- a/lib/jsonModels/Data.dart
+++ b/lib/jsonModels/Data.dart
@@ -1,0 +1,80 @@
+import 'Links.dart';
+
+class Data {
+  int id;
+  String commonName;
+  String slug;
+  String scientificName;
+  int year;
+  String bibliography;
+  String author;
+  String status;
+  String rank;
+  String familyCommonName;
+  int genusId;
+  String imageUrl;
+  List<String> synonyms;
+  String genus;
+  String family;
+  Links links;
+
+  Data(
+      {this.id,
+        this.commonName,
+        this.slug,
+        this.scientificName,
+        this.year,
+        this.bibliography,
+        this.author,
+        this.status,
+        this.rank,
+        this.familyCommonName,
+        this.genusId,
+        this.imageUrl,
+        this.synonyms,
+        this.genus,
+        this.family,
+        this.links});
+
+  Data.fromJson(Map<String, dynamic> json) {
+    id = json['id'];
+    commonName = json['common_name'];
+    slug = json['slug'];
+    scientificName = json['scientific_name'];
+    year = json['year'];
+    bibliography = json['bibliography'];
+    author = json['author'];
+    status = json['status'];
+    rank = json['rank'];
+    familyCommonName = json['family_common_name'];
+    genusId = json['genus_id'];
+    imageUrl = json['image_url'];
+    synonyms = json['synonyms'].cast<String>();
+    genus = json['genus'];
+    family = json['family'];
+    links = json['links'] != null ? new Links.fromJson(json['links']) : null;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = new Map<String, dynamic>();
+    data['id'] = this.id;
+    data['common_name'] = this.commonName;
+    data['slug'] = this.slug;
+    data['scientific_name'] = this.scientificName;
+    data['year'] = this.year;
+    data['bibliography'] = this.bibliography;
+    data['author'] = this.author;
+    data['status'] = this.status;
+    data['rank'] = this.rank;
+    data['family_common_name'] = this.familyCommonName;
+    data['genus_id'] = this.genusId;
+    data['image_url'] = this.imageUrl;
+    data['synonyms'] = this.synonyms;
+    data['genus'] = this.genus;
+    data['family'] = this.family;
+    if (this.links != null) {
+      data['links'] = this.links.toJson();
+    }
+    return data;
+  }
+}

--- a/lib/jsonModels/LinkData.dart
+++ b/lib/jsonModels/LinkData.dart
@@ -1,0 +1,21 @@
+class LinkData {
+  String self;
+  String first;
+  String last;
+
+  LinkData({this.self, this.first, this.last});
+
+  LinkData.fromJson(Map<String, dynamic> json) {
+    self = json['self'];
+    first = json['first'];
+    last = json['last'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = new Map<String, dynamic>();
+    data['self'] = this.self;
+    data['first'] = this.first;
+    data['last'] = this.last;
+    return data;
+  }
+}

--- a/lib/jsonModels/Links.dart
+++ b/lib/jsonModels/Links.dart
@@ -1,0 +1,22 @@
+class Links {
+  String self;
+  String plant;
+  String genus;
+
+  Links({this.self, this.plant, this.genus});
+
+  Links.fromJson(Map<String, dynamic> json) {
+    self = json['self'];
+    plant = json['plant'];
+    genus = json['genus'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = new Map<String, dynamic>();
+    data['self'] = this.self;
+    data['plant'] = this.plant;
+    data['genus'] = this.genus;
+    return data;
+  }
+}
+

--- a/lib/jsonModels/Meta.dart
+++ b/lib/jsonModels/Meta.dart
@@ -1,0 +1,15 @@
+class Meta {
+  int total;
+
+  Meta({this.total});
+
+  Meta.fromJson(Map<String, dynamic> json) {
+    total = json['total'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = new Map<String, dynamic>();
+    data['total'] = this.total;
+    return data;
+  }
+}

--- a/lib/screens/home/home_page.dart
+++ b/lib/screens/home/home_page.dart
@@ -4,6 +4,8 @@ import 'package:lorax/screens/tab_views/gardening.dart';
 import 'package:lorax/screens/tab_views/trees.dart';
 import 'package:flutter_icons/flutter_icons.dart';
 
+import '../plictionary.dart';
+
 class HomePage extends StatefulWidget {
   @override
   _HomePageState createState() => _HomePageState();
@@ -34,6 +36,23 @@ class _HomePageState extends State<HomePage> {
                 Icons.account_circle,
               ),
             ),
+            actions: <Widget>[
+              Padding(
+                  padding: EdgeInsets.only(right: 20.0),
+                  child: GestureDetector(
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (context) {
+                            return Plictionary();
+                          },
+                        ),
+                      );
+                    },
+                    child: Icon(FlutterIcons.dictionary_mco),
+                  )
+              ),
+            ],
             bottom: TabBar(
               tabs: [
                 Tab(icon: Icon(FlutterIcons.tree_mco)),

--- a/lib/screens/plictionary.dart
+++ b/lib/screens/plictionary.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_icons/flutter_icons.dart';
+import 'package:http/http.dart' as http;
+import 'package:lorax/jsonModels/Data.dart';
+import 'package:lorax/jsonModels/LinkData.dart';
+import 'package:lorax/jsonModels/Meta.dart';
+
+class Plictionary extends StatefulWidget {
+  @override
+  _Plictionary createState() => new _Plictionary();
+}
+
+class _Plictionary extends State<Plictionary> {
+  List<Data> data;
+  LinkData links;
+  Meta meta;
+
+  Future<String> getData(String query) async {
+    FocusScope.of(context).unfocus();
+    var client = new http.Client();
+    try {
+      var queryLink = 'https://trefle.io/api/v1/plants/search?token=peNaBhmqKnjLb0G67WeBbMW-q0w6HBBXY4_jrDmmOyU&q=$query';
+      print(queryLink);
+      var response = await client.get(queryLink);
+      var parsed = json.decode(response.body);
+      if (parsed['data'] != null) {
+        data = new List<Data>();
+        parsed['data'].forEach((v) {
+          data.add(new Data.fromJson(v));
+        });
+      }
+      links = parsed['links'] != null
+          ? new LinkData.fromJson(parsed['links'])
+          : null;
+      meta = parsed['meta'] != null ? new Meta.fromJson(parsed['meta']) : null;
+
+      //print(meta.total);
+      //print(data[0].author); Total number of responses is stored in meta.total
+    } finally {
+      client.close();
+    }
+
+    return "Success!";
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    TextEditingController _controller = TextEditingController();
+    return new Scaffold(
+      appBar: AppBar(
+        title: Text("Plant Dictionary"),
+      ),
+      body: new Center(
+        child: new Container(
+            padding: const EdgeInsets.all(30.0),
+            color: Colors.white,
+            child: new Container(
+                child: new Center(
+                    child: new Column(children: [
+              new Text(
+                'Search for any plant',
+                style: new TextStyle(fontSize: 25.0),
+              ),
+              new Padding(padding: EdgeInsets.only(top: 50.0)),
+              new TextFormField(
+                controller: _controller,
+                decoration: new InputDecoration(
+                  suffixIcon: IconButton(
+                    onPressed: () => {
+                      getData(_controller.text)
+                    },
+                    icon: Icon(FlutterIcons.search_mdi),
+                  ),
+                  labelText: "Enter Plant Name",
+                  fillColor: Colors.white,
+                  border: new OutlineInputBorder(
+                    borderRadius: new BorderRadius.circular(25.0),
+                    borderSide: new BorderSide(),
+                  ),
+                  //fillColor: Colors.green
+                ),
+                keyboardType: TextInputType.text,
+                style: new TextStyle(
+                  fontFamily: "Poppins",
+                ),
+              ),
+            ])))),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   moor_flutter: ^2.0.0
   simple_animations: ^1.3.4
   flutter_local_notifications: 1.4.4+3
+  http: ^0.12.2
 
 
 dev_dependencies:


### PR DESCRIPTION
Data about plants can be searched and fetched using the trefle API. 

**TODO:** 

- Create a UI to display the data fetched. 

**NOTES:**

- All the models for the data returned are in the `jsonModels` directory. 
- To see what parameter each returned field contains, check out the model files. 
- A couple of sample commented statements are present in the `getData()` method of `plictionary.dart` which show how to use the fetched data. 